### PR TITLE
Drop TYPO3_MODE usage in configuration

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -11,20 +11,15 @@ call_user_func(function () {
                     }
                 }
             }
-        ')
-    );
-    if (TYPO3_MODE === 'BE') {
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
-            trim('
-                module.tx_form {
-                    settings {
-                        yamlConfigurations {
-                            100 = EXT:form_mailtext/Configuration/Form/MailtextFormSetup.yaml
-                        }
+            module.tx_form {
+                settings {
+                    yamlConfigurations {
+                        100 = EXT:form_mailtext/Configuration/Form/MailtextFormSetup.yaml
                     }
                 }
-            ')
-        );
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['EXT:form/Resources/Private/Language/Database.xlf'][] = 'EXT:form_mailtext/Resources/Private/Language/Database.xlf';
-    }
+            }
+        ')
+    );
+
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['EXT:form/Resources/Private/Language/Database.xlf'][] = 'EXT:form_mailtext/Resources/Private/Language/Database.xlf';
 });

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 call_user_func(function () {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(


### PR DESCRIPTION
This is not necessary and also deprecated with TYPO3v11.

See https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/master/Deprecation-92947-DeprecateTYPO3_MODEAndTYPO3_REQUESTTYPEConstants.html